### PR TITLE
Disable service worker cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,22 +29,22 @@ jobs:
               # Fix Warnings CI=false is just a baaad workaround
               CI=false npm run build
               npm run deploy-develop
-              aws s3 cp s3://3box-dapp-develop.3box.io/service-worker.js s3://3box-dapp-develop.3box.io/service-worker.js --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type application/javascript --acl public-read
-              aws s3 cp s3://3box-dapp-develop.3box.io/index.html s3://3box-dapp-develop.3box.io/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --acl public-read
+              chmod +x cache.sh
+              ./cache-service-worker.sh develop
               npm run invalidate E17Q4403A4B4C8
             fi
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               CI=false npm run build
               npm run deploy-master
-              aws s3 cp s3://3box-dapp-master.3box.io/service-worker.js s3://3box-dapp-master.3box.io/service-worker.js --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type application/javascript --acl public-read
-              aws s3 cp s3://3box-dapp-master.3box.io/index.html s3://3box-dapp-master.3box.io/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --acl public-read
+              chmod +x cache.sh
+              ./cache-service-worker.sh master
               npm run invalidate ET1S25F7JOQM6
             fi
             if [[ "${CIRCLE_BRANCH}" == *"release/"* ]]; then
               CI=false npm run build
               npm run deploy-test
-              aws s3 cp s3://3box-dapp-test.3box.io/service-worker.js s3://3box-dapp-test.3box.io/service-worker.js --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type application/javascript --acl public-read
-              aws s3 cp s3://3box-dapp-test.3box.io/index.html s3://3box-dapp-test.3box.io/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --acl public-read
+              chmod +x cache.sh
+              ./cache-service-worker.sh test
               npm run invalidate E256JNRDZ1B3QM
             fi
 

--- a/cache.sh
+++ b/cache.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+STAGE=$1
+aws s3 cp s3://3box-dapp-"$STAGE".3box.io/service-worker.js s3://3box-dapp-"$STAGE".3box.io/service-worker.js --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type application/javascript --acl public-read
+aws s3 cp s3://3box-dapp-"$STAGE".3box.io/index.html s3://3box-dapp-"$STAGE".3box.io/index.html --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --acl public-read

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "scss": "node-sass --watch scss -o css",
     "lint": "eslint src --ignore-path .gitignore",
     "lint-fix": "eslint src --fix --ignore-path .gitignore",
-    "deploy-to-s3": "node_modules/.bin/s3-deploy './build/**' --cwd './build/' --region us-east-1 --bucket",
+    "deploy-to-s3": "node_modules/.bin/s3-deploy './build/**' --cwd './build/' --deleteRemoved --cache 604800 --region us-east-1 --bucket",
     "invalidate": "node_modules/.bin/aws-cloudfront-invalidate",
     "deploy-develop": "npm run deploy-to-s3 3box-dapp-develop.3box.io && npm run invalidate E17Q4403A4B4C8",
     "deploy-master": "npm run deploy-to-s3 3box-dapp-master.3box.io && npm run invalidate ET1S25F7JOQM6",


### PR DESCRIPTION
This PR does:
- Caches all the assets with an expiration of 1 week (images, js, css)
- Removes from the S3 bucket older versions of the dapp
- Disables any server cache for both `index.html` and `service-worker.js` like suggested in the thread https://github.com/facebook/create-react-app/issues/3082#issuecomment-327626847

Invalidates all cached files after a new deployment.