### PR TITLE
fix: (de)serialize date in known way

### DIFF
--- a/src/state/actions/signin/openBox.js
+++ b/src/state/actions/signin/openBox.js
@@ -98,7 +98,7 @@ const openBox = fromSignIn => async (dispatch) => {
         const date = Date.now();
         const dateJoined = new Date(date);
         const memberSinceDate = `${(dateJoined.getMonth() + 1)}/${dateJoined.getDate()}/${dateJoined.getFullYear()}`;
-        store.getState().myData.box.public.set('memberSince', dateJoined);
+        store.getState().myData.box.public.set('memberSince', dateJoined.toString())
         dispatch({
           type: 'MY_MEMBERSINCE_UPDATE',
           memberSince: memberSinceDate,


### PR DESCRIPTION
Fix for https://github.com/3box/3box-js/issues/524 

Date obj can be (de)serialized differently in different environment, avoid by explicitly serializing. 

If you consume this value anywhere else, check if it is received as expected.

Should make release as soon as possible, since this issue will cause all new accounts to fail and makes the dapp unusable.