### PR TITLE
Bug fix. If there is no currentNetwork then links will not work

### DIFF
--- a/src/views/Profile/FeedTile.jsx
+++ b/src/views/Profile/FeedTile.jsx
@@ -121,7 +121,7 @@ export const FeedTileInternal = (props) => {
   const isMain = currentNetwork && currentNetwork.toLowerCase() === 'main';
   let txURL;
 
-  if (isMain) {
+  if (isMain || typeof currentNetwork === 'undefined') {
     txURL = `https://etherscan.io/tx/${item.hash}`;
   } else {
     txURL = `https://${currentNetwork}.etherscan.io/tx/${item.hash}`;
@@ -235,7 +235,7 @@ export const FeedTileToken = (props) => {
   const isMain = currentNetwork && currentNetwork.toLowerCase() === 'main';
   let txURL;
 
-  if (isMain) {
+  if (isMain || typeof currentNetwork === 'undefined') {
     txURL = `https://etherscan.io/tx/${item.hash}`;
   } else {
     txURL = `https://${currentNetwork}.etherscan.io/tx/${item.hash}`;
@@ -340,7 +340,7 @@ export const FeedTileTXS = (props) => {
   const isMain = currentNetwork && currentNetwork.toLowerCase() === 'main';
   let txURL;
 
-  if (isMain) {
+  if (isMain || typeof currentNetwork === 'undefined') {
     txURL = `https://etherscan.io/tx/${item.hash}`;
   } else {
     txURL = `https://${currentNetwork}.etherscan.io/tx/${item.hash}`;


### PR DESCRIPTION
Viewing the application in a browser with no ethereum network causes the application to give erroneous links.

![image](https://user-images.githubusercontent.com/5702426/74757769-5c801700-526e-11ea-8897-9a9f4ca137f3.png)
