### PR TITLE
Add legacy web3 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3box-dapp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5270,6 +5270,11 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
       }
+    },
+    "@metamask/legacy-web3": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/legacy-web3/-/legacy-web3-1.1.0.tgz",
+      "integrity": "sha512-ERd3jsLFnHfdDnN8hRFchEH0ac1g2UgR9plZShQEq+EFCKp8q2HIXTtqazQEAkb38mJiX65uyJ+XQRV3Kl8M8g=="
     },
     "@microlink/mql": {
       "version": "0.5.23",
@@ -14174,7 +14179,7 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
       "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
@@ -24604,6 +24609,10 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "webrtcsupport": {
+          "version": "github:ipfs/webrtcsupport#0a7099ff04fd36227a32e16966dbb3cca7002378",
+          "from": "github:ipfs/webrtcsupport"
         }
       }
     },
@@ -32665,7 +32674,7 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
       "from": "github:web3-js/scrypt-shim",
       "requires": {
         "scryptsy": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "3box-chatbox-react": "^0.1.9",
     "3id-resolver": "0.0.6",
     "@babel/polyfill": "^7.7.0",
+    "@metamask/legacy-web3": "^1.1.0",
     "@microlink/mql": "^0.5.10",
     "@portis/web3": "^2.0.0-beta.54",
     "@walletconnect/web3-provider": "^1.0.0-beta.47",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import '@babel/polyfill';
+import '@metamask/legacy-web3';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router } from 'react-router-dom';


### PR DESCRIPTION
I tested locally without problem but until MetaMask actually stops injecting `window.web3` I don't know how we can check for sure it works as expected?